### PR TITLE
Prepare shipmight 0.1.14

### DIFF
--- a/charts/shipmight/Chart.yaml
+++ b/charts/shipmight/Chart.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: v2
 name: shipmight
-version: "0.1.13"
-kubeVersion: ">= v1.21.4"
+version: "0.1.14"
+kubeVersion: ">= 1.21.4 < 1.22.0"

--- a/charts/shipmight/values.yaml
+++ b/charts/shipmight/values.yaml
@@ -3,7 +3,7 @@
 image:
   registry: ghcr.io
   repository: shipmight/shipmight
-  tag: "0.1.13"
+  tag: "0.1.14"
   pullPolicy: IfNotPresent
   pullSecrets: []
 


### PR DESCRIPTION
Changes:

- Fixes Chart.yaml by setting `apiVersion: v2`
- Adds upper kubeVersion constraint